### PR TITLE
add build-dep for ncurses

### DIFF
--- a/zsh/snapcraft.yaml
+++ b/zsh/snapcraft.yaml
@@ -18,4 +18,4 @@ parts:
     source: git://git.code.sf.net/p/zsh/code
     plugin: autotools
     install-via: prefix
-    build-packages: [yodl]
+    build-packages: [yodl, libncursesw5-dev]


### PR DESCRIPTION
Add a build dep for libncursesw5-dev: shared libraries for terminal handling (wide character support)
